### PR TITLE
std::hash<QString> specialization is available in Qt 5.14

### DIFF
--- a/src/QtStdHash.h
+++ b/src/QtStdHash.h
@@ -4,6 +4,7 @@
 #include "qstring.h"
 #include "qhash.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 namespace std
 {
 template<> struct hash<QString>
@@ -14,5 +15,6 @@ template<> struct hash<QString>
     }
 };
 }
+#endif
 
 #endif // QTSTDHASH_H


### PR DESCRIPTION
fixes building with Qt 5.14 (Visual Studio)

"explicit specialization; 'std::hash<QString>' has already been defined"